### PR TITLE
Fix Linux binary filename

### DIFF
--- a/peoplesanspeople_binaries/run.sh
+++ b/peoplesanspeople_binaries/run.sh
@@ -72,7 +72,7 @@ fi
 
 if [[ ${target} == "Linux" ]]
 then
-  binary_dir=$binary_dir"/PeopleSansPeople.x86_64"
+  binary_dir=$binary_dir"/PeopleSansPeople"
   binary_dir=$(echo $binary_dir | tr -s / /)
 "${binary_dir}" -logfile "-" --scenario-config-file ${scenario_config} | tee  ${logfile}
 fi


### PR DESCRIPTION
Following the instructions from https://github.com/Unity-Technologies/PeopleSansPeople/tree/main/peoplesanspeople_binaries#running-the-linux-binary, I downloaded the Linux binary archive file but the filename expected in https://github.com/Unity-Technologies/PeopleSansPeople/blob/751ca17b81b863bbd32902f33a7a875ac26751e0/peoplesanspeople_binaries/run.sh#L75 is different than the one in the archive.

![archive_content](https://user-images.githubusercontent.com/66578286/161385535-1cb0e3e6-c129-41ce-893b-a8bc2eacc270.png)
